### PR TITLE
Implement crash teleport script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# a
+# BeamNG Crash Teleport Tool
+
+This project contains a simple Lua script that teleports your vehicle to a random **crash** location in BeamNG.drive. These spots are intended to leave the car in awkward positions so you can tow it back to a garage or recovery point.
+
+## How it works
+- A list of crash coordinates is defined in `lua/crash_teleport.lua`.
+- When executed, the script chooses one at random and moves the active vehicle there.
+- You can customize the coordinates to match the map you are playing.
+
+To use the script, place it inside your BeamNG mod's `lua` folder and invoke `crashTeleport.teleportRandomCrash()` via a key binding or UI button.
+
+## Getting Started with Git
+
+1. Initialize the repository (if you haven't already):
+   ```bash
+   git init
+   ```
+2. Add files to track:
+   ```bash
+   git add <file>
+   ```
+3. Commit your changes:
+   ```bash
+   git commit -m "Describe your changes"
+   ```
+4. Push to GitHub:
+   ```bash
+   git remote add origin <your-repo-url>
+   git push -u origin main
+   ```

--- a/lua/crash_teleport.lua
+++ b/lua/crash_teleport.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+-- Example crash locations (adjust to match your map)
+local crashPoints = {
+  {pos = vec3(100, 200, 50), rot = quat(0, 0, 0, 1)},
+  {pos = vec3(-150, 75, 60),  rot = quat(0, 0, 1, 0)},
+  {pos = vec3(50, -300, 45),  rot = quat(0, 1, 0, 0)},
+}
+
+--- Teleports the player's vehicle to a random crash point
+local function teleportRandomCrash()
+  local vehicle = be:getPlayerVehicle(0)
+  if not vehicle or #crashPoints == 0 then return end
+  local idx = math.random(#crashPoints)
+  local target = crashPoints[idx]
+  vehicle:setPosition(target.pos, target.rot)
+end
+
+M.teleportRandomCrash = teleportRandomCrash
+return M
+


### PR DESCRIPTION
## Summary
- adjust README to describe crash teleport use-case
- add `crash_teleport.lua` with example crash locations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840682912c4832ca77c4353ec811a10