### PR TITLE
Enhance crash teleport with automatic map coords

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This project contains a simple Lua script that teleports your vehicle to a random **crash** location in BeamNG.drive. These spots are intended to leave the car in awkward positions so you can tow it back to a garage or recovery point. The mod now comes with a tiny UI app so you can trigger a random crash with a single button press.
 
 ## How it works
-- When the mod loads it searches the map for available spawn spheres and uses them as crash locations.
+- When the mod loads it searches the map for available spawn spheres and uses them as crash locations. If none are found, a few built-in sample points are used instead.
 - The script chooses a random location and moves the active vehicle there when triggered.
-- You can still add extra spots at runtime with `crashTeleport.addCrashPoint(pos, rot)`.
+- You can still add extra spots at runtime with `crash_teleport.addCrashPoint(pos, rot)`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # BeamNG Crash Teleport Tool
 
-This project contains a simple Lua script that teleports your vehicle to a random **crash** location in BeamNG.drive. These spots are intended to leave the car in awkward positions so you can tow it back to a garage or recovery point.
+This project contains a simple Lua script that teleports your vehicle to a random **crash** location in BeamNG.drive. These spots are intended to leave the car in awkward positions so you can tow it back to a garage or recovery point. The mod now comes with a tiny UI app so you can trigger a random crash with a single button press.
 
 ## How it works
-- A list of crash coordinates is defined in `lua/crash_teleport.lua`.
-- When executed, the script chooses one at random and moves the active vehicle there.
-- You can customize the coordinates to match the map you are playing.
+- When the mod loads it searches the map for available spawn spheres and uses them as crash locations.
+- The script chooses a random location and moves the active vehicle there when triggered.
+- You can still add extra spots at runtime with `crashTeleport.addCrashPoint(pos, rot)`.
 
-To use the script, place it inside your BeamNG mod's `lua` folder and invoke `crashTeleport.teleportRandomCrash()` via a key binding or UI button.
+## Installation
+
+1. Copy or clone this repository into your `Documents/BeamNG.drive/mods/unpacked/crashTeleport` folder.
+2. Start BeamNG.drive and enable the mod if prompted.
+3. While in game, open the UI app menu and add the **Crash Teleport** app.
+4. Press the **Teleport to Crash** button to instantly move your vehicle to a random crash spot.
 
 ## Getting Started with Git
 

--- a/info.json
+++ b/info.json
@@ -1,0 +1,7 @@
+{
+  "Name": "Crash Teleport Tool",
+  "Author": "OpenAI Codex",
+  "Description": "Teleport your vehicle to random crash scenes via a single button.",
+  "Version": "1.1",
+  "mainScript": "lua/main.lua"
+}

--- a/lua/crash_teleport.lua
+++ b/lua/crash_teleport.lua
@@ -1,20 +1,31 @@
 local M = {}
 -- Crash locations automatically populated at startup
 local crashPoints = {}
+local defaultPoints = {
+  {pos = vec3(100, 200, 50), rot = quat(0, 0, 0, 1)},
+  {pos = vec3(-150, 75, 60),  rot = quat(0, 0, 1, 0)},
+  {pos = vec3(50, -300, 45),  rot = quat(0, 1, 0, 0)},
+  {pos = vec3(200, 100, 40),  rot = quat(1, 0, 0, 0)},
+}
 
 -- Attempts to gather crash points from map spawn spheres
 local function initCrashPoints()
   crashPoints = {}
   local spawns = scenetree.findClassObjects('SpawnSphere')
-  if not spawns then return end
-  for _, id in ipairs(spawns) do
-    local obj = scenetree.findObjectById(id)
-    if obj then
-      table.insert(crashPoints, {
-        pos = obj:getPosition(),
-        rot = obj:getRotation(),
-      })
+  if spawns then
+    for _, id in ipairs(spawns) do
+      local obj = scenetree.findObjectById(id)
+      if obj then
+        table.insert(crashPoints, {
+          pos = obj:getPosition(),
+          rot = obj:getRotation(),
+        })
+      end
     end
+  end
+  -- If no spawns were found, fall back to built-in points
+  if #crashPoints == 0 then
+    crashPoints = defaultPoints
   end
 end
 

--- a/lua/crash_teleport.lua
+++ b/lua/crash_teleport.lua
@@ -1,11 +1,26 @@
 local M = {}
+-- Crash locations automatically populated at startup
+local crashPoints = {}
 
--- Example crash locations (adjust to match your map)
-local crashPoints = {
-  {pos = vec3(100, 200, 50), rot = quat(0, 0, 0, 1)},
-  {pos = vec3(-150, 75, 60),  rot = quat(0, 0, 1, 0)},
-  {pos = vec3(50, -300, 45),  rot = quat(0, 1, 0, 0)},
-}
+-- Attempts to gather crash points from map spawn spheres
+local function initCrashPoints()
+  crashPoints = {}
+  local spawns = scenetree.findClassObjects('SpawnSphere')
+  if not spawns then return end
+  for _, id in ipairs(spawns) do
+    local obj = scenetree.findObjectById(id)
+    if obj then
+      table.insert(crashPoints, {
+        pos = obj:getPosition(),
+        rot = obj:getRotation(),
+      })
+    end
+  end
+end
+
+local function onInit()
+  initCrashPoints()
+end
 
 --- Teleports the player's vehicle to a random crash point
 local function teleportRandomCrash()
@@ -16,6 +31,25 @@ local function teleportRandomCrash()
   vehicle:setPosition(target.pos, target.rot)
 end
 
+-- Adds a new crash location at runtime
+local function addCrashPoint(pos, rot)
+  table.insert(crashPoints, {pos = pos, rot = rot or quat(0, 0, 0, 1)})
+end
+
+-- Clears all crash points
+local function clearCrashPoints()
+  crashPoints = {}
+end
+
+-- Returns all crash points (useful for debugging)
+local function getCrashPoints()
+  return crashPoints
+end
+
 M.teleportRandomCrash = teleportRandomCrash
+M.addCrashPoint = addCrashPoint
+M.clearCrashPoints = clearCrashPoints
+M.getCrashPoints = getCrashPoints
+M.onInit = onInit
 return M
 

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+local function onInit()
+  extensions.load('crash_teleport')
+end
+
+M.onInit = onInit
+return M

--- a/ui/modules/apps/crashTeleport/crashTeleportApp.html
+++ b/ui/modules/apps/crashTeleport/crashTeleportApp.html
@@ -1,0 +1,3 @@
+<div class="crash-teleport-app">
+  <button class="bng-button" ng-click="teleport()">Teleport to Crash</button>
+</div>

--- a/ui/modules/apps/crashTeleport/crashTeleportApp.js
+++ b/ui/modules/apps/crashTeleport/crashTeleportApp.js
@@ -1,0 +1,12 @@
+angular.module('beamng.apps').directive('crashTeleportApp', ['bngApi', function(bngApi) {
+  return {
+    templateUrl: '/ui/modules/apps/crashTeleport/crashTeleportApp.html',
+    replace: true,
+    restrict: 'EA',
+    link: function(scope) {
+      scope.teleport = function() {
+        bngApi.engineLua('crashTeleport.teleportRandomCrash()')
+      }
+    }
+  }
+}])

--- a/ui/modules/apps/crashTeleport/crashTeleportApp.js
+++ b/ui/modules/apps/crashTeleport/crashTeleportApp.js
@@ -5,7 +5,7 @@ angular.module('beamng.apps').directive('crashTeleportApp', ['bngApi', function(
     restrict: 'EA',
     link: function(scope) {
       scope.teleport = function() {
-        bngApi.engineLua('crashTeleport.teleportRandomCrash()')
+        bngApi.engineLua('crash_teleport.teleportRandomCrash()')
       }
     }
   }


### PR DESCRIPTION
## Summary
- auto-detect spawn spheres as crash locations on load
- document automatic crash point generation

## Testing
- `luac -p lua/crash_teleport.lua`
- `luac -p lua/main.lua`
- `apt-get install -y lua5.3`


------
https://chatgpt.com/codex/tasks/task_e_68406bff08e0832c8f02090c5bcfc55f