### PR TITLE
Add random crash point generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # BeamNG Crash Teleport Tool
 
-This project contains a simple Lua script that teleports your vehicle to a random **crash** location in BeamNG.drive. These spots are intended to leave the car in awkward positions so you can tow it back to a garage or recovery point.
+This project contains a simple Lua script that teleports your vehicle to a random **crash** location in BeamNG.drive. These spots are intended to leave the car in awkward positions so you can tow it back to a garage or recovery point. The mod now comes with a tiny UI app so you can trigger a random crash with a single button press.
 
 ## How it works
-- A list of crash coordinates is defined in `lua/crash_teleport.lua`.
-- When executed, the script chooses one at random and moves the active vehicle there.
-- You can customize the coordinates to match the map you are playing.
+- When the mod loads it searches the map for available spawn spheres and uses them as crash locations. If none are found it will attempt to generate random locations across the map using ground raycasts. As a last resort a few built-in sample points are used.
+- The script chooses a random location and moves the active vehicle there when triggered.
+- You can still add extra spots at runtime with `crash_teleport.addCrashPoint(pos, rot)`.
 
-To use the script, place it inside your BeamNG mod's `lua` folder and invoke `crashTeleport.teleportRandomCrash()` via a key binding or UI button.
+## Installation
+
+1. Copy or clone this repository into your `Documents/BeamNG.drive/mods/unpacked/crashTeleport` folder.
+2. Start BeamNG.drive and enable the mod if prompted.
+3. While in game, open the UI app menu and add the **Crash Teleport** app.
+4. Press the **Teleport to Crash** button to instantly move your vehicle to a random crash spot.
 
 ## Getting Started with Git
 

--- a/info.json
+++ b/info.json
@@ -1,0 +1,7 @@
+{
+  "Name": "Crash Teleport Tool",
+  "Author": "OpenAI Codex",
+  "Description": "Teleport your vehicle to random crash scenes via a single button.",
+  "Version": "1.1",
+  "mainScript": "lua/main.lua"
+}

--- a/lua/crash_teleport.lua
+++ b/lua/crash_teleport.lua
@@ -1,21 +1,106 @@
 local M = {}
 
--- Example crash locations (adjust to match your map)
-local crashPoints = {
+-- Crash locations automatically populated at startup
+local crashPoints = {}
+local defaultPoints = {
   {pos = vec3(100, 200, 50), rot = quat(0, 0, 0, 1)},
   {pos = vec3(-150, 75, 60),  rot = quat(0, 0, 1, 0)},
   {pos = vec3(50, -300, 45),  rot = quat(0, 1, 0, 0)},
+  {pos = vec3(200, 100, 40),  rot = quat(1, 0, 0, 0)},
 }
 
---- Teleports the player's vehicle to a random crash point
-local function teleportRandomCrash()
-  local vehicle = be:getPlayerVehicle(0)
-  if not vehicle or #crashPoints == 0 then return end
-  local idx = math.random(#crashPoints)
-  local target = crashPoints[idx]
-  vehicle:setPosition(target.pos, target.rot)
+-- Creates random crash locations across the map by raycasting to the ground
+local function generateRandomPoints(count)
+  local veh = be:getPlayerVehicle(0)
+  if not veh then return end
+
+  local mapMin = vec3(-2000, -2000, 0) -- adjust for your map size
+  local mapMax = vec3(2000, 2000, 0)
+  local attempts = 0
+
+  while #crashPoints < count and attempts < count * 10 do
+    local x = mapMin.x + math.random() * (mapMax.x - mapMin.x)
+    local y = mapMin.y + math.random() * (mapMax.y - mapMin.y)
+    local z = mapMin.z + 100
+
+    local from = vec3(x, y, z)
+    local to   = vec3(x, y, z - 200)
+    local result = veh:castRayStatic(from, to)
+
+    if result and result.hit then
+      local spawnZ = result.pos.z + 1
+      table.insert(crashPoints, {
+        pos = vec3(x, y, spawnZ),
+        rot = quat(0, 0, 0, 1)
+      })
+    end
+    attempts = attempts + 1
+  end
 end
 
-M.teleportRandomCrash = teleportRandomCrash
+-- Attempts to gather crash points from map spawn spheres
+local function initCrashPoints()
+  crashPoints = {}
+  local spawns = scenetree.findClassObjects('SpawnSphere')
+  if spawns then
+    for _, id in ipairs(spawns) do
+      local obj = scenetree.findObjectById(id)
+      if obj then
+        table.insert(crashPoints, {
+          pos = obj:getPosition(),
+          rot = obj:getRotation(),
+        })
+      end
+    end
+  end
+
+  if #crashPoints == 0 then
+    generateRandomPoints(50)
+  end
+
+  if #crashPoints == 0 then
+    crashPoints = defaultPoints
+  end
+end
+
+local function onExtensionLoaded()
+  initCrashPoints()
+end
+
+--- Teleports the player's vehicle to a random crash point
+local function teleportToRandomCrash()
+  if #crashPoints == 0 then
+    log("E", "crashTeleport", "No crash points available!")
+    return
+  end
+
+  local vehicle = be:getPlayerVehicle(0)
+  if not vehicle then return end
+  local idx = math.random(#crashPoints)
+  local target = crashPoints[idx]
+  vehicle:setPositionRotation(target.pos.x, target.pos.y, target.pos.z,
+    target.rot.x, target.rot.y, target.rot.z, target.rot.w)
+end
+
+-- Adds a new crash location at runtime
+local function addCrashPoint(pos, rot)
+  table.insert(crashPoints, {pos = pos, rot = rot or quat(0, 0, 0, 1)})
+end
+
+-- Clears all crash points
+local function clearCrashPoints()
+  crashPoints = {}
+end
+
+-- Returns all crash points (useful for debugging)
+local function getCrashPoints()
+  return crashPoints
+end
+
+M.teleportToRandomCrash = teleportToRandomCrash
+M.addCrashPoint = addCrashPoint
+M.clearCrashPoints = clearCrashPoints
+M.getCrashPoints = getCrashPoints
+M.onExtensionLoaded = onExtensionLoaded
 return M
 

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+local function onInit()
+  extensions.load('crash_teleport')
+end
+
+M.onInit = onInit
+return M

--- a/ui/modules/apps/crashTeleport/crashTeleportApp.html
+++ b/ui/modules/apps/crashTeleport/crashTeleportApp.html
@@ -1,0 +1,3 @@
+<div class="crash-teleport-app">
+  <button class="bng-button" ng-click="teleport()">Teleport to Crash</button>
+</div>

--- a/ui/modules/apps/crashTeleport/crashTeleportApp.js
+++ b/ui/modules/apps/crashTeleport/crashTeleportApp.js
@@ -1,0 +1,12 @@
+angular.module('beamng.apps').directive('crashTeleportApp', ['bngApi', function(bngApi) {
+  return {
+    templateUrl: '/ui/modules/apps/crashTeleport/crashTeleportApp.html',
+    replace: true,
+    restrict: 'EA',
+    link: function(scope) {
+      scope.teleport = function() {
+        bngApi.engineLua('crash_teleport.teleportToRandomCrash()')
+      }
+    }
+  }
+}])


### PR DESCRIPTION
## Summary
- generate random crash points with raycasts when no spawn spheres
- rename teleport function to `teleportToRandomCrash`
- update UI app to use new function
- document random point generation in README

## Testing
- `apt-get install -y lua5.3`
- `luac -p lua/crash_teleport.lua`
- `luac -p lua/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68406bff08e0832c8f02090c5bcfc55f